### PR TITLE
Fix async DB session usage

### DIFF
--- a/order/app/db/session.py
+++ b/order/app/db/session.py
@@ -1,5 +1,4 @@
 import logging
-from sqlmodel import SQLModel
 from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker, AsyncSession
 from order.app.core.config import settings
 from opentelemetry import trace


### PR DESCRIPTION
## Summary
- correct the DB session type in `create_order`
- await commit/refresh/rollback calls
- remove unused `SQLModel` import

## Testing
- `ruff check`
- `black order/app/api/routes.py order/app/db/session.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688bf7784c8c832e967a5a3e5c44f39a